### PR TITLE
Update scrollend.js

### DIFF
--- a/src/scrollend.js
+++ b/src/scrollend.js
@@ -50,7 +50,9 @@ if (!supported) {
             }
             else {
               // dispatch
-              scrollport.dispatchEvent(scrollendEvent);
+              if (scrollport) {
+                scrollport.dispatchEvent(scrollendEvent);
+              }
               timeout = 0;
             }
           }, 100);


### PR DESCRIPTION
Edge case of element being removed and so "this" reference no longer applies, resulting in undefined.dispatchEvent syntax error