### PR TITLE
Remove pointers on touchcancel

### DIFF
--- a/src/scrollend.js
+++ b/src/scrollend.js
@@ -15,6 +15,11 @@ if (!supported) {
       pointers.delete(touch.identifier)
   }, {passive: true});
 
+  document.addEventListener('touchcancel', e => {
+    for (let touch of e.changedTouches)
+      pointers.delete(touch.identifier)
+  }, {passive: true});
+
   // Map of scroll-observed elements.
   let observed = new WeakMap();
 


### PR DESCRIPTION
I was running into a bug in an app that used this library: after swiping along the bottom of the screen on a fullscreen iPhone web app as to switch apps, my web app would no longer receive `scrollend`s.

On a `touchcancel` (e.g. swiping the bottom of the screen for app switcher when app is fullscreen, like via `WKWebView`), the `pointers` set would never get rid of the canceled pointer, preventing `scrollend` from ever firing until restarting the application.

This is a minimal effort PR that seemed a little better than just opening an issue – I haven't verified the problem nor the fix on a minimal project (although from simply reading the code, it does seem like a real issue?), and I haven't looked at how `dist` should be built – thought I'd throw this up first to make sure you're on board.

& thanks for the library!