### PR TITLE
bubbling 'scrollend' event; always new event args instance; passive internal scroll listener

### DIFF
--- a/src/scrollend.js
+++ b/src/scrollend.js
@@ -1,7 +1,6 @@
 const supported = typeof window == 'undefined' ? true : "onscrollend" in window;
 
 if (!supported) {
-  const scrollendEvent = new Event('scrollend');
   const pointers = new Set();
 
   // Track if any pointer is active
@@ -56,7 +55,7 @@ if (!supported) {
             else {
               // dispatch
               if (scrollport) {
-                scrollport.dispatchEvent(scrollendEvent);
+                scrollport.dispatchEvent(new Event('scrollend'));
               }
               timeout = 0;
             }
@@ -64,7 +63,7 @@ if (!supported) {
         },
         listeners: 0, // Count of number of listeners.
       };
-      originalFn.apply(scrollport, ['scroll', data.scrollListener]);
+      originalFn.apply(scrollport, ['scroll', data.scrollListener, {passive: true}]);
       observed.set(scrollport, data);
     }
     data.listeners++;


### PR DESCRIPTION
As [discussed](https://github.com/argyleink/scrollyfills/discussions/22)

- made 'scrollend' event a bubbling event to match native behavior
- and will create a new event args instance when raising the event
- internal scroll listener is now passive

I verified that the options object that is used to register the `scroll` listener is not needed when removing the listener again. (Matching options are only required for the `capture` flag. But I wasn't 100% sure so I verified it.)

Edit:
I hope I'm not getting on your nerves... today I experimented and found that the native `scrollend` event does not bubble up the DOM. I don't know why I believed I observed a bubbling DOM event a few days ago. My MR needs more work and more thought.

superseded by https://github.com/argyleink/scrollyfills/pull/24